### PR TITLE
kill hald-addon-usb-cable after psfreedom loads

### DIFF
--- a/n900/psfreedom-enable-n900.sh
+++ b/n900/psfreedom-enable-n900.sh
@@ -44,11 +44,14 @@ if ! grep -q psfreedom /proc/modules; then
     insmod psfreedom.ko
     RC=$?                                    
 fi                                                                   
-                                                            
+
 if [ $RC != 0 ]; then                                              
     logger "$0: failed to install psfreedom module"                      
     exit 1                                                      
 fi                                                              
-                               
+
+sleep 1
+
+killall hald-addon-usb-cable 2>/dev/null || logger "$0: hald-addon-usb-cable is not running"
 
 exit 0


### PR DESCRIPTION
I had to use killall since pgrep does not work with "hald-addon-usb-cable" since it's too long.
And I had to put a sleep since hal restarts the addon when psfreedom loads
