### PR TITLE
Fix minor bug

### DIFF
--- a/psfreedom_devices.c
+++ b/psfreedom_devices.c
@@ -432,7 +432,6 @@ static int devices_setup(struct usb_gadget *gadget,
        */
       *(u8 *)(req->buf + w_length) = 0;
       DBG(dev, "ASBESTOS [LV2]: %s\n",(char *)req->buf);
-      value = 0;
       break;
     case ASBESTOS_GET_STAGE2_SIZE:
       if (ctrl->bRequestType == 0xc0) {


### PR DESCRIPTION
Return a value >= 0 in ASBESTOS_PRINT_DBG_MSG isn't correct, we just have to ignore the request with -ENOTSUPP and print the message
